### PR TITLE
Fixed arguments error

### DIFF
--- a/src/skymin/bossbar/BossBarAPI.php
+++ b/src/skymin/bossbar/BossBarAPI.php
@@ -84,7 +84,7 @@ final class BossBarAPI{
 				0.0,
 				0.0,
 				0.0,
-				[new Attribute(Att::HEALTH, 0.0, 100.0, 100.0, 100.0)],
+				[new Attribute(Att::HEALTH, 0.0, 100.0, 100.0, 100.0, [])],
 				$metadata->getAll(),
 				[]
 			);


### PR DESCRIPTION
### Purpose
Update for [PocketMine-MP latest release](https://github.com/pmmp/PocketMine-MP/releases/tag/4.7.0)  
  
  
### Error
```
Too few arguments to function pocketmine\network\mcpe\protocol\types\entity\Attribute::__construct(), 5 passed in phar://xxx/virions/bossbarapi_dev-19.phar/src/skymin/bossbar/BossBarAPI.php on line 87 and exactly 6 expected
```